### PR TITLE
feat(client): optional beforePayment pre-sign hook (dependency-free)

### DIFF
--- a/.changeset/heavy-buses-guard.md
+++ b/.changeset/heavy-buses-guard.md
@@ -2,4 +2,4 @@
 "x402-solana": minor
 ---
 
-Add optional `beforePayment` hook to the client. It runs after a 402 response is parsed and a payment requirement is selected, before the payment transaction is built and signed. Return `{ abort: true, reason }` to refuse the payment - the wallet's `signTransaction` is never invoked and the wrapped fetch throws. Enables drop-in payment policy such as spend rules, allow/deny lists, or a seller trust preflight (see the twzrd-x402-gate example in the README and `examples/twzrd-guard.mjs`).
+Add optional `beforePayment` hook to the client. It runs after a 402 response is parsed and a payment requirement is selected, before the payment transaction is built and signed. Return `{ abort: true, reason }` to refuse the payment - the wallet's `signTransaction` is never invoked and the wrapped fetch throws. Enables drop-in payment policy such as spend rules, allow/deny lists, velocity caps, or a seller reputation preflight. An unhandled throw inside the hook aborts the payment (fail-closed). See the README and `examples/before-payment-guard.mjs`.

--- a/.changeset/heavy-buses-guard.md
+++ b/.changeset/heavy-buses-guard.md
@@ -1,0 +1,5 @@
+---
+"x402-solana": minor
+---
+
+Add optional `beforePayment` hook to the client. It runs after a 402 response is parsed and a payment requirement is selected, before the payment transaction is built and signed. Return `{ abort: true, reason }` to refuse the payment - the wallet's `signTransaction` is never invoked and the wrapped fetch throws. Enables drop-in payment policy such as spend rules, allow/deny lists, or a seller trust preflight (see the twzrd-x402-gate example in the README and `examples/twzrd-guard.mjs`).

--- a/README.md
+++ b/README.md
@@ -183,42 +183,48 @@ payment transaction is built and signed**. Return `{ abort: true, reason }`
 to refuse the payment - the wallet's `signTransaction` is never called and
 `client.fetch` throws.
 
-Use it for spend rules, allow/deny lists, or a trust preflight on the seller
-wallet. Example with [twzrd-x402-gate](https://www.npmjs.com/package/twzrd-x402-gate)
-(free TWZRD readiness check on the `payTo` wallet before any signature):
+Use it for spend rules, allow/deny lists, velocity caps, or a reputation
+preflight on the seller wallet. The hook is a plain function - no dependency
+required:
 
 ```typescript
 import { createX402Client } from 'x402-solana/client';
-import { twzrdBeforePaymentCreation } from 'twzrd-x402-gate';
+
+const MAX_LAMPORTS = 1_000_000n; // refuse anything above this
+const ALLOWED = new Set(['MerchantWa11et...']);
 
 const client = createX402Client({
   wallet,
   network: 'solana',
-  beforePayment: (requirements, context) =>
-    twzrdBeforePaymentCreation(
-      { ...requirements, resource: requirements.resource ?? context.resourceUrl },
-      { gateOnCanSpend: true }, // strict: refuse unless TWZRD vouches (can_spend)
-    ),
+  beforePayment: (requirements) => {
+    if (!ALLOWED.has(requirements.payTo)) {
+      return { abort: true, reason: `seller_not_allowlisted:${requirements.payTo}` };
+    }
+    if (BigInt(requirements.maxAmountRequired) > MAX_LAMPORTS) {
+      return { abort: true, reason: 'amount_above_cap' };
+    }
+    // return nothing (or { abort: false }) to proceed to signing
+  },
 });
 
-// Payments to blocked/unknown sellers now throw BEFORE the wallet signs:
-// "Payment aborted by beforePayment hook: [twzrd] twzrd_can_spend_false payTo=..."
+// Refused payments throw BEFORE the wallet signs:
+// "Payment aborted by beforePayment hook: seller_not_allowlisted:..."
 ```
 
-Choosing a policy:
+The hook may be async, so it can call an external policy or reputation service
+before deciding. It runs on every payment attempt, after requirement selection
+and before transaction construction, which makes it the last deterministic
+checkpoint at which a payment can be refused without a signature.
 
-- **Decision-only (default)**: omit `gateOnCanSpend` - only sellers TWZRD
-  flags as `block` (or wash-flagged merchants, which are refused by default)
-  are aborted; `warn` proceeds. Safe to adopt without disrupting existing flows.
-- **Strict mode** (`gateOnCanSpend: true`): additionally refuse whenever the
-  free preflight cannot vouch for the seller (`can_spend=false`). Use when the
-  application requires an affirmative trust signal before any signature.
+Failure semantics: an unhandled throw inside the hook aborts the payment
+(fail-closed) rather than falling through to a signature.
 
-A runnable zero-funds demo (local 402 merchant + signer spy asserting the
-wallet is never invoked) lives in [`examples/twzrd-guard.mjs`](./examples/twzrd-guard.mjs):
+A runnable zero-funds demo (local 402 merchant + a signer spy asserting the
+wallet is never invoked on refusal) lives in
+[`examples/before-payment-guard.mjs`](./examples/before-payment-guard.mjs):
 
 ```bash
-npm run example:twzrd-guard
+npm run example:before-payment-guard
 ```
 
 #### Using with a Proxy Server (CORS Bypass)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ required:
 ```typescript
 import { createX402Client } from 'x402-solana/client';
 
-const MAX_LAMPORTS = 1_000_000n; // refuse anything above this
+const MAX_AMOUNT_BASE_UNITS = 1_000_000n; // 1 USDC (6 decimals)
 const ALLOWED = new Set(['MerchantWa11et...']);
 
 const client = createX402Client({
@@ -200,7 +200,15 @@ const client = createX402Client({
     if (!ALLOWED.has(requirements.payTo)) {
       return { abort: true, reason: `seller_not_allowlisted:${requirements.payTo}` };
     }
-    if (BigInt(requirements.maxAmountRequired) > MAX_LAMPORTS) {
+    const amount =
+      requirements.amount ??
+      ('maxAmountRequired' in requirements
+        ? String(requirements.maxAmountRequired)
+        : undefined);
+    if (!amount) {
+      return { abort: true, reason: 'missing_amount' };
+    }
+    if (BigInt(amount) > MAX_AMOUNT_BASE_UNITS) {
       return { abort: true, reason: 'amount_above_cap' };
     }
     // return nothing (or { abort: false }) to proceed to signing
@@ -212,12 +220,16 @@ const client = createX402Client({
 ```
 
 The hook may be async, so it can call an external policy or reputation service
-before deciding. It runs on every payment attempt, after requirement selection
-and before transaction construction, which makes it the last deterministic
-checkpoint at which a payment can be refused without a signature.
+before deciding. It receives a detached snapshot of the selected requirements;
+mutating the snapshot does not change what the client builds, signs, or sends.
+The client's configured `amount` limit is enforced first, so over-limit
+requirements are rejected without invoking the hook. For requirements that
+pass that limit, the hook is the last deterministic checkpoint at which a
+payment can be refused without a signature.
 
 Failure semantics: an unhandled throw inside the hook aborts the payment
-(fail-closed) rather than falling through to a signature.
+(fail-closed) rather than falling through to a signature. Returning `undefined`
+or `{ abort: false }` proceeds; returning `{ abort: true }` refuses.
 
 A runnable zero-funds demo (local 402 merchant + a signer spy asserting the
 wallet is never invoked on refusal) lives in

--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ import { createX402Client } from 'x402-solana/client';
 
 const MAX_AMOUNT_BASE_UNITS = 1_000_000n; // 1 USDC (6 decimals)
 const ALLOWED = new Set(['MerchantWa11et...']);
+const USDC_MAINNET = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const SOLANA_MAINNET = new Set([
+  'solana',
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+]);
 
 const client = createX402Client({
   wallet,
@@ -200,15 +205,13 @@ const client = createX402Client({
     if (!ALLOWED.has(requirements.payTo)) {
       return { abort: true, reason: `seller_not_allowlisted:${requirements.payTo}` };
     }
-    const amount =
-      requirements.amount ??
-      ('maxAmountRequired' in requirements
-        ? String(requirements.maxAmountRequired)
-        : undefined);
-    if (!amount) {
-      return { abort: true, reason: 'missing_amount' };
+    if (requirements.asset !== USDC_MAINNET) {
+      return { abort: true, reason: 'unsupported_asset' };
     }
-    if (BigInt(amount) > MAX_AMOUNT_BASE_UNITS) {
+    if (!SOLANA_MAINNET.has(requirements.network)) {
+      return { abort: true, reason: 'unsupported_network' };
+    }
+    if (BigInt(requirements.amount) > MAX_AMOUNT_BASE_UNITS) {
       return { abort: true, reason: 'amount_above_cap' };
     }
     // return nothing (or { abort: false }) to proceed to signing

--- a/README.md
+++ b/README.md
@@ -175,6 +175,52 @@ function MyComponent() {
 }
 ```
 
+#### Pre-payment policy hook (beforePayment)
+
+The client accepts an optional `beforePayment` hook that runs after a 402
+response is parsed and a payment requirement is selected, but **before the
+payment transaction is built and signed**. Return `{ abort: true, reason }`
+to refuse the payment - the wallet's `signTransaction` is never called and
+`client.fetch` throws.
+
+Use it for spend rules, allow/deny lists, or a trust preflight on the seller
+wallet. Example with [twzrd-x402-gate](https://www.npmjs.com/package/twzrd-x402-gate)
+(free TWZRD readiness check on the `payTo` wallet before any signature):
+
+```typescript
+import { createX402Client } from 'x402-solana/client';
+import { twzrdBeforePaymentCreation } from 'twzrd-x402-gate';
+
+const client = createX402Client({
+  wallet,
+  network: 'solana',
+  beforePayment: (requirements, context) =>
+    twzrdBeforePaymentCreation(
+      { ...requirements, resource: requirements.resource ?? context.resourceUrl },
+      { gateOnCanSpend: true }, // strict: refuse unless TWZRD vouches (can_spend)
+    ),
+});
+
+// Payments to blocked/unknown sellers now throw BEFORE the wallet signs:
+// "Payment aborted by beforePayment hook: [twzrd] twzrd_can_spend_false payTo=..."
+```
+
+Choosing a policy:
+
+- **Decision-only (default)**: omit `gateOnCanSpend` - only sellers TWZRD
+  flags as `block` (or wash-flagged merchants, which are refused by default)
+  are aborted; `warn` proceeds. Safe to adopt without disrupting existing flows.
+- **Strict mode** (`gateOnCanSpend: true`): additionally refuse whenever the
+  free preflight cannot vouch for the seller (`can_spend=false`). Use when the
+  application requires an affirmative trust signal before any signature.
+
+A runnable zero-funds demo (local 402 merchant + signer spy asserting the
+wallet is never invoked) lives in [`examples/twzrd-guard.mjs`](./examples/twzrd-guard.mjs):
+
+```bash
+npm run example:twzrd-guard
+```
+
 #### Using with a Proxy Server (CORS Bypass)
 
 If you're making requests from a browser to external APIs and encountering CORS issues, you can provide a custom fetch function that routes requests through your proxy server:
@@ -561,6 +607,7 @@ Creates a new x402 client instance.
   rpcUrl?: string;                    // Optional custom RPC
   amount?: bigint;                    // Optional safety limit (max payment)
   customFetch?: typeof fetch;         // Optional custom fetch for proxy support
+  beforePayment?: BeforePaymentHook;  // Optional policy hook - abort before signing
   verbose?: boolean;                  // Optional debug logging
 }
 ```

--- a/examples/before-payment-guard.mjs
+++ b/examples/before-payment-guard.mjs
@@ -1,53 +1,32 @@
 #!/usr/bin/env node
 /**
- * Guard-before-sign example: x402-solana + twzrd-x402-gate
+ * Guard-before-sign example for the `beforePayment` hook.
  *
- * Wires a TWZRD trust preflight into the client's `beforePayment` hook so a
- * payment to an untrusted seller is refused BEFORE the wallet ever signs.
+ * Demonstrates the hook's core contract: a policy refusal happens BEFORE the
+ * wallet is ever asked to sign. The policy here is a plain function with no
+ * dependencies - swap it for your own spend rules, allow/deny list, velocity
+ * cap, or a call to whatever reputation service you use.
  *
- * The script is a self-asserting, zero-funds demo:
+ * Self-asserting, zero-funds demo:
  *   - starts a local x402 merchant that returns 402 (v2 PAYMENT-REQUIRED header)
  *   - wraps a signer spy that counts (and fails on) any signTransaction call
- *   - runs the client with strict policy (gateOnCanSpend: true)
- *   - asserts: payment aborted with reason `twzrd_can_spend_false`,
- *     signer invocations === 0, no payment retry sent
+ *   - runs the client with a policy that refuses a non-allowlisted seller
+ *   - asserts: payment aborted, signer invocations === 0, no payment retry sent
  *
- * Run (offline, deterministic - TWZRD intel responses are stubbed):
- *   npm run build && node examples/twzrd-guard.mjs
- *
- * Run against the live TWZRD free preflight (still zero-spend - the preflight
- * is free and the payment is refused before signing):
- *   node examples/twzrd-guard.mjs --live
+ * Run:
+ *   npm run build && node examples/before-payment-guard.mjs
  */
 
 import { createServer } from "node:http";
 import { createX402Client } from "../dist/client/index.mjs";
-import { twzrdBeforePaymentCreation } from "twzrd-x402-gate";
 
-const LIVE = process.argv.includes("--live");
-
-// An unknown seller wallet. The TWZRD free preflight cannot vouch for an
-// unknown wallet (can_spend=false), so strict mode refuses the payment.
 const UNKNOWN_SELLER = "7cVfgArCheMR6Cs4t6vz5rfnqd56vZq4ndaBrY5xkxXy";
 const USDC_MAINNET = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const SOLANA_MAINNET_CAIP2 = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
 
-/** Offline stub of the TWZRD intel API (free preflight + merchant card). */
-const stubbedIntelFetch = async (url) => {
-  const path = new URL(url).pathname;
-  if (path === "/v1/intel/preflight") {
-    return Response.json({
-      readiness_card: {
-        decision: "warn",
-        can_spend: false,
-        trust_score: 41,
-        seller_wallet: UNKNOWN_SELLER,
-      },
-    });
-  }
-  // merchant card: unknown seller, not wash flagged
-  return Response.json({ pay_to: UNKNOWN_SELLER, wash_flagged: false });
-};
+// The payer's policy: only these sellers may be paid, and never above the cap.
+const ALLOWED_SELLERS = new Set(["TrustedMerchant1111111111111111111111111111"]);
+const MAX_AMOUNT_BASE_UNITS = 100_000n; // 0.10 USDC
 
 // --- 1. Local x402 merchant: always answers 402 with v2 requirements -------
 const paymentRequired = {
@@ -68,7 +47,9 @@ const paymentRequired = {
   extensions: {},
 };
 
+let paymentRetries = 0;
 const merchant = createServer((req, res) => {
+  if (req.headers["payment-signature"]) paymentRetries += 1;
   res.writeHead(402, {
     "content-type": "application/json",
     "PAYMENT-REQUIRED": Buffer.from(JSON.stringify(paymentRequired)).toString("base64"),
@@ -89,24 +70,24 @@ const wallet = {
   },
 };
 
-// --- 3. Client with the TWZRD guard in the beforePayment seat --------------
+// --- 3. Client with a payer-owned policy in the beforePayment seat ---------
 const client = createX402Client({
   wallet,
   network: "solana",
-  beforePayment: (requirements, context) =>
-    twzrdBeforePaymentCreation(
-      { ...requirements, resource: requirements.resource ?? context.resourceUrl },
-      {
-        gateOnCanSpend: true, // strict mode: TWZRD must vouch before any signature
-        ...(LIVE ? {} : { fetch: stubbedIntelFetch }),
-      },
-    ),
+  beforePayment: (requirements) => {
+    if (!ALLOWED_SELLERS.has(requirements.payTo)) {
+      return { abort: true, reason: `seller_not_allowlisted:${requirements.payTo}` };
+    }
+    if (BigInt(requirements.maxAmountRequired ?? requirements.amount) > MAX_AMOUNT_BASE_UNITS) {
+      return { abort: true, reason: "amount_above_cap" };
+    }
+    // proceed to signing
+  },
 });
 
 // --- 4. Attempt the payment and assert the contract ------------------------
-console.log(`mode:      ${LIVE ? "LIVE (intel.twzrd.xyz free preflight)" : "offline (stubbed intel)"}`);
 console.log(`merchant:  ${merchantUrl}`);
-console.log(`payTo:     ${UNKNOWN_SELLER} (unknown seller)`);
+console.log(`payTo:     ${UNKNOWN_SELLER} (not allowlisted)`);
 
 let aborted = null;
 try {
@@ -119,11 +100,13 @@ merchant.close();
 
 const pass =
   aborted !== null &&
-  /twzrd/.test(String(aborted.message)) &&
-  signInvocations === 0;
+  /seller_not_allowlisted/.test(String(aborted.message)) &&
+  signInvocations === 0 &&
+  paymentRetries === 0;
 
 console.log(`\ndecision:  ${aborted ? "REFUSED before signing" : "approved"}`);
 if (aborted) console.log(`reason:    ${aborted.message}`);
 console.log(`signer invocations: ${signInvocations}`);
+console.log(`payment retries sent: ${paymentRetries}`);
 console.log(pass ? "\nPASS - payment refused, wallet never signed" : "\nFAIL");
 process.exit(pass ? 0 : 1);

--- a/examples/twzrd-guard.mjs
+++ b/examples/twzrd-guard.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Guard-before-sign example: x402-solana + twzrd-x402-gate
+ *
+ * Wires a TWZRD trust preflight into the client's `beforePayment` hook so a
+ * payment to an untrusted seller is refused BEFORE the wallet ever signs.
+ *
+ * The script is a self-asserting, zero-funds demo:
+ *   - starts a local x402 merchant that returns 402 (v2 PAYMENT-REQUIRED header)
+ *   - wraps a signer spy that counts (and fails on) any signTransaction call
+ *   - runs the client with strict policy (gateOnCanSpend: true)
+ *   - asserts: payment aborted with reason `twzrd_can_spend_false`,
+ *     signer invocations === 0, no payment retry sent
+ *
+ * Run (offline, deterministic - TWZRD intel responses are stubbed):
+ *   npm run build && node examples/twzrd-guard.mjs
+ *
+ * Run against the live TWZRD free preflight (still zero-spend - the preflight
+ * is free and the payment is refused before signing):
+ *   node examples/twzrd-guard.mjs --live
+ */
+
+import { createServer } from "node:http";
+import { createX402Client } from "../dist/client/index.mjs";
+import { twzrdBeforePaymentCreation } from "twzrd-x402-gate";
+
+const LIVE = process.argv.includes("--live");
+
+// An unknown seller wallet. The TWZRD free preflight cannot vouch for an
+// unknown wallet (can_spend=false), so strict mode refuses the payment.
+const UNKNOWN_SELLER = "7cVfgArCheMR6Cs4t6vz5rfnqd56vZq4ndaBrY5xkxXy";
+const USDC_MAINNET = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SOLANA_MAINNET_CAIP2 = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+
+/** Offline stub of the TWZRD intel API (free preflight + merchant card). */
+const stubbedIntelFetch = async (url) => {
+  const path = new URL(url).pathname;
+  if (path === "/v1/intel/preflight") {
+    return Response.json({
+      readiness_card: {
+        decision: "warn",
+        can_spend: false,
+        trust_score: 41,
+        seller_wallet: UNKNOWN_SELLER,
+      },
+    });
+  }
+  // merchant card: unknown seller, not wash flagged
+  return Response.json({ pay_to: UNKNOWN_SELLER, wash_flagged: false });
+};
+
+// --- 1. Local x402 merchant: always answers 402 with v2 requirements -------
+const paymentRequired = {
+  x402Version: 2,
+  error: "PAYMENT-SIGNATURE header is required",
+  resource: { url: "/paid", description: "Demo paid endpoint", mimeType: "application/json" },
+  accepts: [
+    {
+      scheme: "exact",
+      network: SOLANA_MAINNET_CAIP2,
+      amount: "50000", // 0.05 USDC
+      asset: USDC_MAINNET,
+      payTo: UNKNOWN_SELLER,
+      maxTimeoutSeconds: 60,
+      extra: { feePayer: "FeePayerWalletAddress12345678901234567890123" },
+    },
+  ],
+  extensions: {},
+};
+
+const merchant = createServer((req, res) => {
+  res.writeHead(402, {
+    "content-type": "application/json",
+    "PAYMENT-REQUIRED": Buffer.from(JSON.stringify(paymentRequired)).toString("base64"),
+  });
+  res.end(JSON.stringify({ message: "Payment required" }));
+});
+
+await new Promise((resolve) => merchant.listen(0, "127.0.0.1", resolve));
+const merchantUrl = `http://127.0.0.1:${merchant.address().port}/paid`;
+
+// --- 2. Signer spy: any signature attempt is an instant failure ------------
+let signInvocations = 0;
+const wallet = {
+  address: "DemoBuyerWallet111111111111111111111111111111",
+  signTransaction: async () => {
+    signInvocations += 1;
+    throw new Error("SIGNER INVOKED - guard-before-sign contract violated");
+  },
+};
+
+// --- 3. Client with the TWZRD guard in the beforePayment seat --------------
+const client = createX402Client({
+  wallet,
+  network: "solana",
+  beforePayment: (requirements, context) =>
+    twzrdBeforePaymentCreation(
+      { ...requirements, resource: requirements.resource ?? context.resourceUrl },
+      {
+        gateOnCanSpend: true, // strict mode: TWZRD must vouch before any signature
+        ...(LIVE ? {} : { fetch: stubbedIntelFetch }),
+      },
+    ),
+});
+
+// --- 4. Attempt the payment and assert the contract ------------------------
+console.log(`mode:      ${LIVE ? "LIVE (intel.twzrd.xyz free preflight)" : "offline (stubbed intel)"}`);
+console.log(`merchant:  ${merchantUrl}`);
+console.log(`payTo:     ${UNKNOWN_SELLER} (unknown seller)`);
+
+let aborted = null;
+try {
+  await client.fetch(merchantUrl);
+} catch (error) {
+  aborted = error;
+}
+
+merchant.close();
+
+const pass =
+  aborted !== null &&
+  /twzrd/.test(String(aborted.message)) &&
+  signInvocations === 0;
+
+console.log(`\ndecision:  ${aborted ? "REFUSED before signing" : "approved"}`);
+if (aborted) console.log(`reason:    ${aborted.message}`);
+console.log(`signer invocations: ${signInvocations}`);
+console.log(pass ? "\nPASS - payment refused, wallet never signed" : "\nFAIL");
+process.exit(pass ? 0 : 1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x402-solana",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x402-solana",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "@payai/facilitator": "^2.2.4",
@@ -7616,6 +7616,18 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "prettier": "^3.7.4",
         "ts-jest": "^29.4.6",
         "tsup": "^8.5.1",
-        "twzrd-x402-gate": "^0.5.3",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -9075,43 +9074,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/twzrd-x402-gate": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/twzrd-x402-gate/-/twzrd-x402-gate-0.5.3.tgz",
-      "integrity": "sha512-dTzlPKwYmaYbOq89u+f7kuQXWdvsRA8bLiSd1iGAus0pk6kG6Xez+JfVc8TBHDd6uwwej01rsfk/dyzl/PAtCQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "twzrd-safe-fetch": "bin/twzrd-safe-fetch.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@scure/base": ">=1.0.0",
-        "@solana/kit": ">=5.1.0",
-        "@x402/core": ">=2.0.0",
-        "@x402/fetch": ">=2.0.0",
-        "@x402/svm": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@scure/base": {
-          "optional": true
-        },
-        "@solana/kit": {
-          "optional": true
-        },
-        "@x402/core": {
-          "optional": true
-        },
-        "@x402/fetch": {
-          "optional": true
-        },
-        "@x402/svm": {
-          "optional": true
-        }
       }
     },
     "node_modules/type-check": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "prettier": "^3.7.4",
         "ts-jest": "^29.4.6",
         "tsup": "^8.5.1",
+        "twzrd-x402-gate": "^0.5.3",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -4332,21 +4333,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -7633,18 +7619,6 @@
         }
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9103,6 +9077,43 @@
         "node": ">= 12"
       }
     },
+    "node_modules/twzrd-x402-gate": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/twzrd-x402-gate/-/twzrd-x402-gate-0.5.3.tgz",
+      "integrity": "sha512-dTzlPKwYmaYbOq89u+f7kuQXWdvsRA8bLiSd1iGAus0pk6kG6Xez+JfVc8TBHDd6uwwej01rsfk/dyzl/PAtCQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "twzrd-safe-fetch": "bin/twzrd-safe-fetch.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@scure/base": ">=1.0.0",
+        "@solana/kit": ">=5.1.0",
+        "@x402/core": ">=2.0.0",
+        "@x402/fetch": ">=2.0.0",
+        "@x402/svm": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@scure/base": {
+          "optional": true
+        },
+        "@solana/kit": {
+          "optional": true
+        },
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/fetch": {
+          "optional": true
+        },
+        "@x402/svm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -9264,21 +9275,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "changeset": "changeset",
     "version": "changeset version",
     "release": "npm run build && changeset publish",
-    "example:twzrd-guard": "npm run build && node examples/twzrd-guard.mjs"
+    "example:before-payment-guard": "npm run build && node examples/before-payment-guard.mjs"
   },
   "dependencies": {
     "@payai/facilitator": "^2.2.4",
@@ -88,7 +88,6 @@
     "prettier": "^3.7.4",
     "ts-jest": "^29.4.6",
     "tsup": "^8.5.1",
-    "twzrd-x402-gate": "^0.5.3",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "prepublishOnly": "npm run clean && npm run build && npm run typecheck",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "npm run build && changeset publish"
+    "release": "npm run build && changeset publish",
+    "example:twzrd-guard": "npm run build && node examples/twzrd-guard.mjs"
   },
   "dependencies": {
     "@payai/facilitator": "^2.2.4",
@@ -87,6 +88,7 @@
     "prettier": "^3.7.4",
     "ts-jest": "^29.4.6",
     "tsup": "^8.5.1",
+    "twzrd-x402-gate": "^0.5.3",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -22,6 +22,7 @@ export class X402Client {
       rpcUrl,
       config.amount || BigInt(0),
       config.verbose || false,
+      config.beforePayment,
     );
   }
 
@@ -42,4 +43,10 @@ export function createX402Client(config: X402ClientConfig): X402Client {
 }
 
 // Re-export types for convenience
-export type { X402ClientConfig, WalletAdapter } from "../types";
+export type {
+  X402ClientConfig,
+  WalletAdapter,
+  BeforePaymentHook,
+  BeforePaymentDecision,
+  BeforePaymentContext,
+} from "../types";

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -46,6 +46,7 @@ export function createX402Client(config: X402ClientConfig): X402Client {
 export type {
   X402ClientConfig,
   WalletAdapter,
+  BeforePaymentRequirements,
   BeforePaymentHook,
   BeforePaymentDecision,
   BeforePaymentContext,

--- a/src/client/payment-interceptor.ts
+++ b/src/client/payment-interceptor.ts
@@ -116,13 +116,17 @@ export function createPaymentFetch(
     const resourceUrl = typeof input === "string" ? input : input.url;
 
     // Run the beforePayment hook (if configured) BEFORE building/signing.
-    // An abort here guarantees the wallet's signTransaction is never called.
+    // Give policy code a detached snapshot so it cannot mutate the canonical
+    // requirements used to build the transaction and payment payload.
     if (beforePayment) {
       log("Running beforePayment hook...");
-      const decision = await beforePayment(selectedRequirements, {
-        resourceUrl,
-        protocolVersion,
-      });
+      const decision = await beforePayment(
+        structuredClone(selectedRequirements),
+        {
+          resourceUrl,
+          protocolVersion,
+        },
+      );
       if (decision && decision.abort === true) {
         const reason = decision.reason || "beforePayment hook aborted payment";
         log("Payment aborted by beforePayment hook:", reason);

--- a/src/client/payment-interceptor.ts
+++ b/src/client/payment-interceptor.ts
@@ -1,6 +1,6 @@
 import type { PaymentRequirements, PaymentRequired } from "@payai/x402/types";
 import { safeBase64Decode } from "@payai/x402/utils";
-import type { WalletAdapter } from "../types";
+import type { BeforePaymentHook, WalletAdapter } from "../types";
 import { isSolanaNetwork } from "../types";
 import { createSolanaPaymentTransaction } from "./transaction-builder";
 import { createPaymentPayload, createPaymentPayloadV1 } from "../utils";
@@ -28,6 +28,7 @@ function decodePaymentRequiredHeader(header: string): PaymentRequired {
  * @param rpcUrl - Solana RPC URL
  * @param maxValue - Maximum payment amount in atomic units (0 = no limit)
  * @param verbose - Enable verbose logging (default: false)
+ * @param beforePayment - Optional hook run after requirement selection, before signing
  * @returns Wrapped fetch function with automatic payment handling
  */
 export function createPaymentFetch(
@@ -36,6 +37,7 @@ export function createPaymentFetch(
   rpcUrl: string,
   maxValue: bigint = BigInt(0),
   verbose: boolean = false,
+  beforePayment?: BeforePaymentHook,
 ) {
   const log = (...args: unknown[]) => {
     if (verbose) console.log("[x402-solana]", ...args);
@@ -112,6 +114,22 @@ export function createPaymentFetch(
 
     // Get the resource URL for the payment payload
     const resourceUrl = typeof input === "string" ? input : input.url;
+
+    // Run the beforePayment hook (if configured) BEFORE building/signing.
+    // An abort here guarantees the wallet's signTransaction is never called.
+    if (beforePayment) {
+      log("Running beforePayment hook...");
+      const decision = await beforePayment(selectedRequirements, {
+        resourceUrl,
+        protocolVersion,
+      });
+      if (decision && decision.abort === true) {
+        const reason = decision.reason || "beforePayment hook aborted payment";
+        log("Payment aborted by beforePayment hook:", reason);
+        throw new Error(`Payment aborted by beforePayment hook: ${reason}`);
+      }
+      log("beforePayment hook approved, continuing...");
+    }
 
     log("Creating signed transaction...");
 

--- a/src/client/payment-interceptor.ts
+++ b/src/client/payment-interceptor.ts
@@ -1,6 +1,11 @@
 import type { PaymentRequirements, PaymentRequired } from "@payai/x402/types";
 import { safeBase64Decode } from "@payai/x402/utils";
-import type { BeforePaymentHook, WalletAdapter } from "../types";
+import type {
+  BeforePaymentContext,
+  BeforePaymentHook,
+  BeforePaymentRequirements,
+  WalletAdapter,
+} from "../types";
 import { isSolanaNetwork } from "../types";
 import { createSolanaPaymentTransaction } from "./transaction-builder";
 import { createPaymentPayload, createPaymentPayloadV1 } from "../utils";
@@ -18,6 +23,30 @@ interface X402ResponseV1 extends PaymentRequired {
 function decodePaymentRequiredHeader(header: string): PaymentRequired {
   const decoded = safeBase64Decode(header);
   return JSON.parse(decoded) as PaymentRequired;
+}
+
+function getRequestSignal(
+  input: RequestInfo,
+  init?: RequestInit,
+): AbortSignal | undefined {
+  return init?.signal ?? (typeof input === "string" ? undefined : input.signal);
+}
+
+function createBeforePaymentSnapshot(
+  requirements: PaymentRequirements,
+): BeforePaymentRequirements {
+  const snapshot = structuredClone(requirements) as Omit<
+    PaymentRequirements,
+    "amount"
+  > & {
+    amount?: string;
+    maxAmountRequired?: string;
+  };
+  const amount = snapshot.amount ?? snapshot.maxAmountRequired;
+  if (!amount) {
+    throw new Error("Missing amount in payment requirements");
+  }
+  return { ...snapshot, amount };
 }
 
 /**
@@ -44,11 +73,14 @@ export function createPaymentFetch(
   };
 
   return async (input: RequestInfo, init?: RequestInit): Promise<Response> => {
-    const url = typeof input === "string" ? input : input.url;
-    log("Making initial request to:", url);
+    const requestUrl = typeof input === "string" ? input : input.url;
+    const signal = getRequestSignal(input, init);
+    signal?.throwIfAborted();
+    log("Making initial request to:", requestUrl);
 
     // Make initial request
     const response = await fetchFn(input, init);
+    signal?.throwIfAborted();
     log("Initial response status:", response.status);
 
     // If not 402, return as-is
@@ -112,21 +144,26 @@ export function createPaymentFetch(
       throw new Error("Payment amount exceeds maximum allowed");
     }
 
-    // Get the resource URL for the payment payload
-    const resourceUrl = typeof input === "string" ? input : input.url;
-
     // Run the beforePayment hook (if configured) BEFORE building/signing.
     // Give policy code a detached snapshot so it cannot mutate the canonical
     // requirements used to build the transaction and payment payload.
     if (beforePayment) {
       log("Running beforePayment hook...");
+      signal?.throwIfAborted();
+      const context: BeforePaymentContext = {
+        requestUrl,
+        responseUrl: response.url || requestUrl,
+        protocolVersion,
+        ...(paymentRequired.resource === undefined
+          ? {}
+          : { declaredResource: paymentRequired.resource }),
+        ...(signal === undefined ? {} : { signal }),
+      };
       const decision = await beforePayment(
-        structuredClone(selectedRequirements),
-        {
-          resourceUrl,
-          protocolVersion,
-        },
+        createBeforePaymentSnapshot(selectedRequirements),
+        context,
       );
+      signal?.throwIfAborted();
       if (decision && decision.abort === true) {
         const reason = decision.reason || "beforePayment hook aborted payment";
         log("Payment aborted by beforePayment hook:", reason);
@@ -136,13 +173,16 @@ export function createPaymentFetch(
     }
 
     log("Creating signed transaction...");
+    signal?.throwIfAborted();
 
     // Create signed transaction
     const signedTransaction = await createSolanaPaymentTransaction(
       wallet,
       selectedRequirements,
       rpcUrl,
+      signal,
     );
+    signal?.throwIfAborted();
     log("Transaction signed successfully");
 
     // Create payment payload based on protocol version
@@ -157,7 +197,7 @@ export function createPaymentFetch(
       paymentHeader = createPaymentPayload(
         signedTransaction,
         selectedRequirements,
-        resourceUrl,
+        requestUrl,
         paymentRequired,
       );
       headerName = "PAYMENT-SIGNATURE";
@@ -183,6 +223,7 @@ export function createPaymentFetch(
     };
 
     log(`Retrying request with ${headerName} header...`);
+    signal?.throwIfAborted();
     const retryResponse = await fetchFn(input, newInit);
     log("Retry response status:", retryResponse.status);
 

--- a/src/client/transaction-builder.ts
+++ b/src/client/transaction-builder.ts
@@ -26,12 +26,14 @@ const DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS = 1; // Minimal price
  * @param wallet - Wallet adapter for signing
  * @param paymentRequirements - Payment requirements from server
  * @param rpcUrl - Solana RPC URL
+ * @param signal - Optional caller cancellation signal
  * @returns Signed VersionedTransaction ready to be serialized
  */
 export async function createSolanaPaymentTransaction(
   wallet: WalletAdapter,
   paymentRequirements: PaymentRequirements,
   rpcUrl: string,
+  signal?: AbortSignal,
 ): Promise<VersionedTransaction> {
   const connection = new Connection(rpcUrl, "confirmed");
 
@@ -163,6 +165,7 @@ export async function createSolanaPaymentTransaction(
     throw new Error("Connected wallet does not support signTransaction");
   }
 
+  signal?.throwIfAborted();
   const userSignedTx = await wallet.signTransaction(transaction);
 
   return userSignedTx;

--- a/src/types/solana-payment.ts
+++ b/src/types/solana-payment.ts
@@ -1,4 +1,5 @@
 import type { VersionedTransaction } from '@solana/web3.js';
+import type { PaymentRequirements } from '@payai/x402/types';
 import type { SolanaNetworkSimple } from './x402-protocol';
 
 /**
@@ -17,6 +18,39 @@ export interface WalletAdapter {
   /** Sign a transaction - required for payment */
   signTransaction: (tx: VersionedTransaction) => Promise<VersionedTransaction>;
 }
+
+/**
+ * Decision returned by a beforePayment hook.
+ * Return `{ abort: true }` (optionally with a reason) to refuse the payment
+ * before any transaction is built or signed. Return `void` / `{ abort: false }`
+ * to proceed.
+ */
+export type BeforePaymentDecision =
+  | { abort: true; reason?: string }
+  | { abort?: false }
+  | void;
+
+/**
+ * Context passed to a beforePayment hook alongside the selected requirements.
+ */
+export interface BeforePaymentContext {
+  /** URL of the resource the payment is for */
+  resourceUrl: string;
+  /** x402 protocol version parsed from the 402 response */
+  protocolVersion: 1 | 2;
+}
+
+/**
+ * Hook invoked after a 402 response is parsed and a payment requirement is
+ * selected, but BEFORE the payment transaction is built and signed.
+ *
+ * Use it to plug in payment policy: spend rules, allow/deny lists, or a
+ * trust/reputation preflight on the payTo wallet.
+ */
+export type BeforePaymentHook = (
+  requirements: PaymentRequirements,
+  context: BeforePaymentContext,
+) => Promise<BeforePaymentDecision> | BeforePaymentDecision;
 
 /**
  * Client configuration for x402 Solana client
@@ -38,6 +72,13 @@ export interface X402ClientConfig {
    * @default globalThis.fetch
    */
   customFetch?: typeof fetch;
+  /**
+   * Optional hook invoked after payment requirements are parsed from a 402
+   * response and BEFORE the payment transaction is built and signed.
+   * Return `{ abort: true, reason }` to refuse the payment - the wallet's
+   * signTransaction is never called and the wrapped fetch throws.
+   */
+  beforePayment?: BeforePaymentHook;
   /** Enable verbose logging for debugging (default: false) */
   verbose?: boolean;
 }

--- a/src/types/solana-payment.ts
+++ b/src/types/solana-payment.ts
@@ -1,6 +1,6 @@
-import type { VersionedTransaction } from '@solana/web3.js';
-import type { PaymentRequirements } from '@payai/x402/types';
-import type { SolanaNetworkSimple } from './x402-protocol';
+import type { VersionedTransaction } from "@solana/web3.js";
+import type { PaymentRequirements, PaymentRequired } from "@payai/x402/types";
+import type { SolanaNetworkSimple } from "./x402-protocol";
 
 /**
  * Solana-specific payment types (v2)
@@ -31,13 +31,31 @@ export type BeforePaymentDecision =
   | void;
 
 /**
+ * Detached policy view of the selected payment requirements.
+ *
+ * `amount` is normalized from the legacy v1 `maxAmountRequired` field when
+ * necessary. The canonical requirements used to build and sign the payment
+ * are not modified.
+ */
+export type BeforePaymentRequirements = Omit<PaymentRequirements, "amount"> & {
+  amount: string;
+  maxAmountRequired?: string;
+};
+
+/**
  * Context passed to a beforePayment hook alongside the selected requirements.
  */
 export interface BeforePaymentContext {
-  /** URL of the resource the payment is for */
-  resourceUrl: string;
+  /** URL originally requested by the caller */
+  requestUrl: string;
+  /** Final response URL, when the fetch implementation exposes one */
+  responseUrl: string;
+  /** Resource declared by the server's payment-required payload, if present */
+  declaredResource?: PaymentRequired["resource"];
   /** x402 protocol version parsed from the 402 response */
   protocolVersion: 1 | 2;
+  /** Caller signal; policy code may use it to cancel external checks */
+  signal?: AbortSignal;
 }
 
 /**
@@ -51,7 +69,7 @@ export interface BeforePaymentContext {
  * Thrown errors propagate and abort the payment.
  */
 export type BeforePaymentHook = (
-  requirements: PaymentRequirements,
+  requirements: BeforePaymentRequirements,
   context: BeforePaymentContext,
 ) => Promise<BeforePaymentDecision> | BeforePaymentDecision;
 

--- a/src/types/solana-payment.ts
+++ b/src/types/solana-payment.ts
@@ -45,7 +45,10 @@ export interface BeforePaymentContext {
  * selected, but BEFORE the payment transaction is built and signed.
  *
  * Use it to plug in payment policy: spend rules, allow/deny lists, or a
- * trust/reputation preflight on the payTo wallet.
+ * trust/reputation preflight on the payTo wallet. The hook receives a detached
+ * snapshot; mutating it does not change the requirements used for payment.
+ * The client's configured amount limit is enforced before this hook runs.
+ * Thrown errors propagate and abort the payment.
  */
 export type BeforePaymentHook = (
   requirements: PaymentRequirements,

--- a/tests/beforePayment.test.ts
+++ b/tests/beforePayment.test.ts
@@ -16,6 +16,7 @@ import {
   createSuccessResponse,
   createV2PaymentRequiredResponse,
   decodePaymentHeader,
+  v1PaymentRequiredDevnet,
   v2PaymentRequired,
 } from './fixtures';
 
@@ -89,10 +90,12 @@ describe('beforePayment hook', () => {
     expect(hook).toHaveBeenCalledTimes(1);
     expect(mockBuildAndSign).toHaveBeenCalledTimes(1);
 
-    // Hook receives the SELECTED requirements plus request context
+    // Hook receives the selected requirements plus request context.
     const [requirements, context] = hook.mock.calls[0] as Parameters<BeforePaymentHook>;
     expect(requirements.payTo).toBe(v2PaymentRequired.accepts[0].payTo);
-    expect(context.resourceUrl).toBe(TEST_URL);
+    expect(context.requestUrl).toBe(TEST_URL);
+    expect(context.responseUrl).toBe(TEST_URL);
+    expect(context.declaredResource).toEqual(v2PaymentRequired.resource);
     expect(context.protocolVersion).toBe(2);
 
     // The retried request carries the payment header
@@ -189,6 +192,71 @@ describe('beforePayment hook', () => {
     expect(wallet.signTransaction).toHaveBeenCalledTimes(0);
     expect(mockBuildAndSign).toHaveBeenCalledTimes(0);
     expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not build, sign, or retry if the request aborts while an async hook is pending', async () => {
+    const wallet = createSpyWallet();
+    const controller = new AbortController();
+    const customFetch = jest.fn(async () => createV2PaymentRequiredResponse());
+    let resolveHook: () => void;
+    let signalHookStarted: () => void;
+    const hookStarted = new Promise<void>((resolve) => {
+      signalHookStarted = resolve;
+    });
+    const hook = jest.fn(
+      () =>
+        new Promise<BeforePaymentDecision>((resolve) => {
+          resolveHook = () => resolve(undefined);
+          signalHookStarted();
+        }),
+    );
+
+    const client = createX402Client({
+      wallet,
+      network: 'solana-devnet',
+      customFetch: customFetch as unknown as typeof fetch,
+      beforePayment: hook,
+    });
+
+    const pending = client.fetch(TEST_URL, { signal: controller.signal });
+    await hookStarted;
+    controller.abort();
+    resolveHook();
+
+    await expect(pending).rejects.toThrow();
+    const [, context] = hook.mock.calls[0] as Parameters<BeforePaymentHook>;
+    expect(context.signal).toBe(controller.signal);
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(0);
+    expect(mockBuildAndSign).toHaveBeenCalledTimes(0);
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes legacy v1 amount for policy and retries with X-PAYMENT after approval', async () => {
+    const hook = jest.fn(async () => undefined);
+    const customFetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(v1PaymentRequiredDevnet), {
+          status: 402,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(createSuccessResponse());
+
+    const client = createX402Client({
+      wallet: mockWallet,
+      network: 'solana-devnet',
+      customFetch: customFetch as unknown as typeof fetch,
+      beforePayment: hook,
+    });
+
+    await client.fetch(TEST_URL);
+
+    const [requirements, context] = hook.mock.calls[0] as Parameters<BeforePaymentHook>;
+    expect(context.protocolVersion).toBe(1);
+    expect(requirements.amount).toBe(v1PaymentRequiredDevnet.accepts[0].maxAmountRequired);
+    const retryInit = customFetch.mock.calls[1][1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>)['X-PAYMENT']).toBeDefined();
   });
 
   describe('payer policy contract', () => {

--- a/tests/beforePayment.test.ts
+++ b/tests/beforePayment.test.ts
@@ -137,32 +137,33 @@ describe('beforePayment hook', () => {
     await expect(client.fetch(TEST_URL)).rejects.toThrow('payTo not on allowlist');
   });
 
-  describe('trust-gate policy contract (twzrd-x402-gate shape)', () => {
-    // Mirrors the decision contract of a pre-payment trust preflight such as
-    // twzrd-x402-gate's twzrdBeforePaymentCreation (the real integration is
-    // demonstrated in examples/twzrd-guard.mjs - that package is ESM-only, so
-    // the contract is locked here with an equivalent local policy).
+  describe('reputation-preflight policy contract', () => {
+    // A payer that consults an external reputation service before signing gets
+    // back some verdict + a "can I spend" flag. This locks the two policy shapes
+    // that matter for the hook, with a local stand-in for the service so the
+    // test has no network dependency: strict (refuse unless vouched) and
+    // decision-only (refuse only on an explicit block).
     interface ReadinessCard {
       decision: 'allow' | 'warn' | 'block';
       can_spend: boolean;
       trust_score: number;
     }
 
-    function trustGatePolicy(
+    function reputationPolicy(
       card: ReadinessCard,
       options: { gateOnCanSpend: boolean },
       onDecision?: (reason: string) => void,
     ): BeforePaymentHook {
       return (): BeforePaymentDecision => {
         if (card.decision === 'block') {
-          onDecision?.(`twzrd_decision_${card.decision}`);
-          return { abort: true, reason: `twzrd_decision_${card.decision}` };
+          onDecision?.(`refused_verdict_${card.decision}`);
+          return { abort: true, reason: `refused_verdict_${card.decision}` };
         }
         if (options.gateOnCanSpend && card.can_spend === false) {
-          onDecision?.('twzrd_can_spend_false');
-          return { abort: true, reason: 'twzrd_can_spend_false' };
+          onDecision?.('refused_not_vouched');
+          return { abort: true, reason: 'refused_not_vouched' };
         }
-        onDecision?.(card.decision === 'warn' ? 'twzrd_warn_allowed' : 'twzrd_allow');
+        onDecision?.(card.decision === 'warn' ? 'allowed_with_warning' : 'allowed');
         return undefined;
       };
     }
@@ -176,18 +177,18 @@ describe('beforePayment hook', () => {
         wallet,
         network: 'solana-devnet',
         customFetch: customFetch as unknown as typeof fetch,
-        beforePayment: trustGatePolicy(
+        beforePayment: reputationPolicy(
           { decision: 'warn', can_spend: false, trust_score: 56 },
           { gateOnCanSpend: true },
           (reason) => decisions.push(reason),
         ),
       });
 
-      await expect(client.fetch(TEST_URL)).rejects.toThrow('twzrd_can_spend_false');
+      await expect(client.fetch(TEST_URL)).rejects.toThrow('refused_not_vouched');
 
       expect(wallet.signTransaction).toHaveBeenCalledTimes(0);
       expect(mockBuildAndSign).toHaveBeenCalledTimes(0);
-      expect(decisions).toEqual(['twzrd_can_spend_false']);
+      expect(decisions).toEqual(['refused_not_vouched']);
     });
 
     it('decision-only default: warn proceeds and the decision is observable', async () => {
@@ -201,7 +202,7 @@ describe('beforePayment hook', () => {
         wallet: mockWallet,
         network: 'solana-devnet',
         customFetch: customFetch as unknown as typeof fetch,
-        beforePayment: trustGatePolicy(
+        beforePayment: reputationPolicy(
           { decision: 'warn', can_spend: false, trust_score: 56 },
           { gateOnCanSpend: false },
           (reason) => decisions.push(reason),
@@ -212,7 +213,7 @@ describe('beforePayment hook', () => {
 
       expect(response.status).toBe(200);
       expect(mockBuildAndSign).toHaveBeenCalledTimes(1);
-      expect(decisions).toEqual(['twzrd_warn_allowed']);
+      expect(decisions).toEqual(['allowed_with_warning']);
     });
   });
 });

--- a/tests/beforePayment.test.ts
+++ b/tests/beforePayment.test.ts
@@ -15,6 +15,7 @@ import {
   mockWallet,
   createSuccessResponse,
   createV2PaymentRequiredResponse,
+  decodePaymentHeader,
   v2PaymentRequired,
 } from './fixtures';
 
@@ -102,6 +103,40 @@ describe('beforePayment hook', () => {
     ).toBeDefined();
   });
 
+  it('isolates payment construction from hook mutations', async () => {
+    const originalRequirements = structuredClone(v2PaymentRequired.accepts[0]);
+    const customFetch = jest
+      .fn()
+      .mockResolvedValueOnce(createV2PaymentRequiredResponse())
+      .mockResolvedValueOnce(createSuccessResponse());
+
+    const client = createX402Client({
+      wallet: mockWallet,
+      network: 'solana-devnet',
+      customFetch: customFetch as unknown as typeof fetch,
+      beforePayment: (requirements) => {
+        requirements.payTo = 'MutatedRecipientWalletAddress';
+        requirements.amount = '999999999';
+        requirements.asset = 'MutatedAssetAddress';
+        requirements.extra.feePayer = 'MutatedFeePayerWalletAddress';
+      },
+    });
+
+    await client.fetch(TEST_URL);
+
+    const builtRequirements = mockBuildAndSign.mock.calls[0]?.[1];
+    expect(builtRequirements).toEqual(originalRequirements);
+
+    const retryInit = customFetch.mock.calls[1]?.[1] as RequestInit;
+    const paymentHeader = (retryInit.headers as Record<string, string>)[
+      'PAYMENT-SIGNATURE'
+    ];
+    const paymentPayload = decodePaymentHeader(paymentHeader) as {
+      accepted: typeof originalRequirements;
+    };
+    expect(paymentPayload.accepted).toEqual(originalRequirements);
+  });
+
   it('never invokes the signer and does not retry when the hook aborts', async () => {
     const wallet = createSpyWallet();
     const customFetch = jest.fn(async () => createV2PaymentRequiredResponse());
@@ -137,38 +172,56 @@ describe('beforePayment hook', () => {
     await expect(client.fetch(TEST_URL)).rejects.toThrow('payTo not on allowlist');
   });
 
-  describe('reputation-preflight policy contract', () => {
-    // A payer that consults an external reputation service before signing gets
-    // back some verdict + a "can I spend" flag. This locks the two policy shapes
-    // that matter for the hook, with a local stand-in for the service so the
-    // test has no network dependency: strict (refuse unless vouched) and
-    // decision-only (refuse only on an explicit block).
-    interface ReadinessCard {
-      decision: 'allow' | 'warn' | 'block';
-      can_spend: boolean;
-      trust_score: number;
+  it('fails closed without building, signing, or retrying when the hook throws', async () => {
+    const wallet = createSpyWallet();
+    const customFetch = jest.fn(async () => createV2PaymentRequiredResponse());
+
+    const client = createX402Client({
+      wallet,
+      network: 'solana-devnet',
+      customFetch: customFetch as unknown as typeof fetch,
+      beforePayment: () => {
+        throw new Error('policy_down');
+      },
+    });
+
+    await expect(client.fetch(TEST_URL)).rejects.toThrow('policy_down');
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(0);
+    expect(mockBuildAndSign).toHaveBeenCalledTimes(0);
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+
+  describe('payer policy contract', () => {
+    // A payer can map any local or remote policy result into the hook's small
+    // abort/proceed contract. These cases cover required approval and advisory
+    // outcomes without coupling the client to a policy provider.
+    interface PolicyResult {
+      outcome: 'approve' | 'review' | 'deny';
+      approved: boolean;
     }
 
-    function reputationPolicy(
-      card: ReadinessCard,
-      options: { gateOnCanSpend: boolean },
+    function createPolicyHook(
+      result: PolicyResult,
+      options: { requireApproval: boolean },
       onDecision?: (reason: string) => void,
     ): BeforePaymentHook {
       return (): BeforePaymentDecision => {
-        if (card.decision === 'block') {
-          onDecision?.(`refused_verdict_${card.decision}`);
-          return { abort: true, reason: `refused_verdict_${card.decision}` };
+        if (result.outcome === 'deny') {
+          onDecision?.('policy_denied');
+          return { abort: true, reason: 'policy_denied' };
         }
-        if (options.gateOnCanSpend && card.can_spend === false) {
-          onDecision?.('refused_not_vouched');
-          return { abort: true, reason: 'refused_not_vouched' };
+        if (options.requireApproval && result.approved === false) {
+          onDecision?.('approval_required');
+          return { abort: true, reason: 'approval_required' };
         }
-        onDecision?.(card.decision === 'warn' ? 'allowed_with_warning' : 'allowed');
+        onDecision?.(
+          result.outcome === 'review' ? 'proceeded_with_review' : 'approved',
+        );
         return undefined;
       };
     }
 
-    it('strict mode: can_spend=false aborts with signer invocation count 0', async () => {
+    it('required approval: approved=false aborts with signer invocation count 0', async () => {
       const wallet = createSpyWallet();
       const customFetch = jest.fn(async () => createV2PaymentRequiredResponse());
       const decisions: string[] = [];
@@ -177,21 +230,21 @@ describe('beforePayment hook', () => {
         wallet,
         network: 'solana-devnet',
         customFetch: customFetch as unknown as typeof fetch,
-        beforePayment: reputationPolicy(
-          { decision: 'warn', can_spend: false, trust_score: 56 },
-          { gateOnCanSpend: true },
+        beforePayment: createPolicyHook(
+          { outcome: 'review', approved: false },
+          { requireApproval: true },
           (reason) => decisions.push(reason),
         ),
       });
 
-      await expect(client.fetch(TEST_URL)).rejects.toThrow('refused_not_vouched');
+      await expect(client.fetch(TEST_URL)).rejects.toThrow('approval_required');
 
       expect(wallet.signTransaction).toHaveBeenCalledTimes(0);
       expect(mockBuildAndSign).toHaveBeenCalledTimes(0);
-      expect(decisions).toEqual(['refused_not_vouched']);
+      expect(decisions).toEqual(['approval_required']);
     });
 
-    it('decision-only default: warn proceeds and the decision is observable', async () => {
+    it('advisory review proceeds and the outcome is observable', async () => {
       const customFetch = jest
         .fn()
         .mockResolvedValueOnce(createV2PaymentRequiredResponse())
@@ -202,9 +255,9 @@ describe('beforePayment hook', () => {
         wallet: mockWallet,
         network: 'solana-devnet',
         customFetch: customFetch as unknown as typeof fetch,
-        beforePayment: reputationPolicy(
-          { decision: 'warn', can_spend: false, trust_score: 56 },
-          { gateOnCanSpend: false },
+        beforePayment: createPolicyHook(
+          { outcome: 'review', approved: false },
+          { requireApproval: false },
           (reason) => decisions.push(reason),
         ),
       });
@@ -213,7 +266,7 @@ describe('beforePayment hook', () => {
 
       expect(response.status).toBe(200);
       expect(mockBuildAndSign).toHaveBeenCalledTimes(1);
-      expect(decisions).toEqual(['allowed_with_warning']);
+      expect(decisions).toEqual(['proceeded_with_review']);
     });
   });
 });

--- a/tests/beforePayment.test.ts
+++ b/tests/beforePayment.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for the beforePayment hook
+ *
+ * Locks the guard-before-sign contract:
+ * - an aborting hook means the wallet signer is NEVER invoked and the
+ *   original request is not retried
+ * - an approving hook leaves the payment flow unchanged
+ */
+
+import type { VersionedTransaction } from '@solana/web3.js';
+import { createX402Client } from '../src/client';
+import { createSolanaPaymentTransaction } from '../src/client/transaction-builder';
+import type { BeforePaymentDecision, BeforePaymentHook, WalletAdapter } from '../src/types';
+import {
+  mockWallet,
+  createSuccessResponse,
+  createV2PaymentRequiredResponse,
+  v2PaymentRequired,
+} from './fixtures';
+
+// Mock the transaction builder: it is the ONLY call site of
+// wallet.signTransaction, so "builder not called" === "signer not called".
+// Mocking it also keeps these tests fully offline (no RPC).
+jest.mock('../src/client/transaction-builder', () => ({
+  createSolanaPaymentTransaction: jest.fn(),
+}));
+
+const mockBuildAndSign = createSolanaPaymentTransaction as jest.MockedFunction<
+  typeof createSolanaPaymentTransaction
+>;
+
+const fakeSignedTransaction = {
+  serialize: () => new Uint8Array([1, 2, 3]),
+} as unknown as VersionedTransaction;
+
+function createSpyWallet(): WalletAdapter & {
+  signTransaction: jest.MockedFunction<WalletAdapter['signTransaction']>;
+} {
+  return {
+    ...mockWallet,
+    signTransaction: jest.fn(async (tx: VersionedTransaction) => tx),
+  };
+}
+
+const TEST_URL = 'https://api.example.com/test';
+
+describe('beforePayment hook', () => {
+  beforeEach(() => {
+    mockBuildAndSign.mockReset();
+    mockBuildAndSign.mockResolvedValue(fakeSignedTransaction);
+  });
+
+  it('is not called for non-402 responses', async () => {
+    const hook = jest.fn();
+    const customFetch = jest.fn(async () => createSuccessResponse());
+
+    const client = createX402Client({
+      wallet: mockWallet,
+      network: 'solana-devnet',
+      customFetch: customFetch as unknown as typeof fetch,
+      beforePayment: hook,
+    });
+
+    const response = await client.fetch(TEST_URL);
+
+    expect(response.status).toBe(200);
+    expect(hook).not.toHaveBeenCalled();
+    expect(mockBuildAndSign).not.toHaveBeenCalled();
+  });
+
+  it('proceeds to build and sign when the hook approves', async () => {
+    const hook = jest.fn(async () => undefined);
+    const customFetch = jest
+      .fn()
+      .mockResolvedValueOnce(createV2PaymentRequiredResponse())
+      .mockResolvedValueOnce(createSuccessResponse());
+
+    const client = createX402Client({
+      wallet: mockWallet,
+      network: 'solana-devnet',
+      customFetch: customFetch as unknown as typeof fetch,
+      beforePayment: hook,
+    });
+
+    const response = await client.fetch(TEST_URL);
+
+    expect(response.status).toBe(200);
+    expect(hook).toHaveBeenCalledTimes(1);
+    expect(mockBuildAndSign).toHaveBeenCalledTimes(1);
+
+    // Hook receives the SELECTED requirements plus request context
+    const [requirements, context] = hook.mock.calls[0] as Parameters<BeforePaymentHook>;
+    expect(requirements.payTo).toBe(v2PaymentRequired.accepts[0].payTo);
+    expect(context.resourceUrl).toBe(TEST_URL);
+    expect(context.protocolVersion).toBe(2);
+
+    // The retried request carries the payment header
+    expect(customFetch).toHaveBeenCalledTimes(2);
+    const retryInit = customFetch.mock.calls[1][1] as RequestInit;
+    expect(
+      (retryInit.headers as Record<string, string>)['PAYMENT-SIGNATURE'],
+    ).toBeDefined();
+  });
+
+  it('never invokes the signer and does not retry when the hook aborts', async () => {
+    const wallet = createSpyWallet();
+    const customFetch = jest.fn(async () => createV2PaymentRequiredResponse());
+
+    const client = createX402Client({
+      wallet,
+      network: 'solana-devnet',
+      customFetch: customFetch as unknown as typeof fetch,
+      beforePayment: () => ({ abort: true }),
+    });
+
+    await expect(client.fetch(TEST_URL)).rejects.toThrow(
+      'Payment aborted by beforePayment hook',
+    );
+
+    // Guard-before-sign: zero signer invocations, zero transaction builds
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(0);
+    expect(mockBuildAndSign).toHaveBeenCalledTimes(0);
+    // Original request only - never retried with a payment header
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the hook reason in the thrown error', async () => {
+    const customFetch = jest.fn(async () => createV2PaymentRequiredResponse());
+
+    const client = createX402Client({
+      wallet: mockWallet,
+      network: 'solana-devnet',
+      customFetch: customFetch as unknown as typeof fetch,
+      beforePayment: () => ({ abort: true, reason: 'payTo not on allowlist' }),
+    });
+
+    await expect(client.fetch(TEST_URL)).rejects.toThrow('payTo not on allowlist');
+  });
+
+  describe('trust-gate policy contract (twzrd-x402-gate shape)', () => {
+    // Mirrors the decision contract of a pre-payment trust preflight such as
+    // twzrd-x402-gate's twzrdBeforePaymentCreation (the real integration is
+    // demonstrated in examples/twzrd-guard.mjs - that package is ESM-only, so
+    // the contract is locked here with an equivalent local policy).
+    interface ReadinessCard {
+      decision: 'allow' | 'warn' | 'block';
+      can_spend: boolean;
+      trust_score: number;
+    }
+
+    function trustGatePolicy(
+      card: ReadinessCard,
+      options: { gateOnCanSpend: boolean },
+      onDecision?: (reason: string) => void,
+    ): BeforePaymentHook {
+      return (): BeforePaymentDecision => {
+        if (card.decision === 'block') {
+          onDecision?.(`twzrd_decision_${card.decision}`);
+          return { abort: true, reason: `twzrd_decision_${card.decision}` };
+        }
+        if (options.gateOnCanSpend && card.can_spend === false) {
+          onDecision?.('twzrd_can_spend_false');
+          return { abort: true, reason: 'twzrd_can_spend_false' };
+        }
+        onDecision?.(card.decision === 'warn' ? 'twzrd_warn_allowed' : 'twzrd_allow');
+        return undefined;
+      };
+    }
+
+    it('strict mode: can_spend=false aborts with signer invocation count 0', async () => {
+      const wallet = createSpyWallet();
+      const customFetch = jest.fn(async () => createV2PaymentRequiredResponse());
+      const decisions: string[] = [];
+
+      const client = createX402Client({
+        wallet,
+        network: 'solana-devnet',
+        customFetch: customFetch as unknown as typeof fetch,
+        beforePayment: trustGatePolicy(
+          { decision: 'warn', can_spend: false, trust_score: 56 },
+          { gateOnCanSpend: true },
+          (reason) => decisions.push(reason),
+        ),
+      });
+
+      await expect(client.fetch(TEST_URL)).rejects.toThrow('twzrd_can_spend_false');
+
+      expect(wallet.signTransaction).toHaveBeenCalledTimes(0);
+      expect(mockBuildAndSign).toHaveBeenCalledTimes(0);
+      expect(decisions).toEqual(['twzrd_can_spend_false']);
+    });
+
+    it('decision-only default: warn proceeds and the decision is observable', async () => {
+      const customFetch = jest
+        .fn()
+        .mockResolvedValueOnce(createV2PaymentRequiredResponse())
+        .mockResolvedValueOnce(createSuccessResponse());
+      const decisions: string[] = [];
+
+      const client = createX402Client({
+        wallet: mockWallet,
+        network: 'solana-devnet',
+        customFetch: customFetch as unknown as typeof fetch,
+        beforePayment: trustGatePolicy(
+          { decision: 'warn', can_spend: false, trust_score: 56 },
+          { gateOnCanSpend: false },
+          (reason) => decisions.push(reason),
+        ),
+      });
+
+      const response = await client.fetch(TEST_URL);
+
+      expect(response.status).toBe(200);
+      expect(mockBuildAndSign).toHaveBeenCalledTimes(1);
+      expect(decisions).toEqual(['twzrd_warn_allowed']);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds an optional `beforePayment` hook to `X402ClientConfig`. It runs after a 402 response is parsed and a payment requirement is selected, **before the payment transaction is built and signed**:

```ts
const client = createX402Client({
  wallet,
  network: 'solana',
  beforePayment: (requirements, context) => {
    if (!allowlist.has(requirements.payTo)) {
      return { abort: true, reason: 'payTo not on allowlist' };
    }
  },
});
```

- Return `{ abort: true, reason }` to refuse — the wallet's `signTransaction` is **never invoked** and `client.fetch` throws. Return `void` / `{ abort: false }` to proceed unchanged.
- An unhandled throw inside the hook aborts the payment (fail-closed).
- The hook receives a detached snapshot of the selected requirements, so policy mutation cannot change what the client builds, signs, or sends.
- The decision contract mirrors the official x402 client's `onBeforePaymentCreation` lifecycle hook, so policy code ports across clients.
- **Non-breaking** (optional config field) and **zero new runtime dependencies** — the hook is a plain function. Point it at spend rules, an allow/deny list, a velocity cap, or a seller-reputation preflight; the client neither knows nor cares which.

Changeset included (minor).

## Status of #38

**#38 is closed in favour of this PR.** It proposed the same seat with a different API shape (`hookFailurePolicy`, fail-open on hook transport errors). This is the single remaining proposal — there is no competing PR to weigh it against.

## Tests (`tests/beforePayment.test.ts`)

Signer-spy contract, fully offline (the transaction builder is mocked — it is the only call site of `wallet.signTransaction`):

- hook is not called for non-402 responses
- approve → flow unchanged: builds, signs, retries with `PAYMENT-SIGNATURE`
- hook mutation → canonical requirements still reach both the transaction builder and serialized payment payload
- abort → **`signTransaction` invocation count 0**, no transaction build, no payment retry
- thrown hook error → fail-closed with no build, signature, or retry
- generic required-approval and advisory-policy shapes remain observable without coupling the client to a provider

## Runnable zero-funds proof

```
npm run example:before-payment-guard
```

`examples/before-payment-guard.mjs` starts a local x402 merchant (v2 `PAYMENT-REQUIRED` header), wires a dependency-free policy function into `beforePayment`, and asserts the contract with a signer spy that **fails the run if it is ever invoked**:

```
decision:  REFUSED before signing
reason:    Payment aborted by beforePayment hook: payTo not on allowlist
signer invocations: 0

PASS - payment refused, wallet never signed
```

No funds, keys, or RPC access required.

---

<sub>Body updated to match the current dependency-free, vendor-neutral diff. No product-specific integration is required by this PR.</sub>
