### PR TITLE
feat(deps)!: replace @payai/x402 with upstream @x402/core 2.21.0

### DIFF
--- a/.changeset/upstream-x402-core.md
+++ b/.changeset/upstream-x402-core.md
@@ -1,0 +1,12 @@
+---
+"x402-solana": minor
+---
+
+Replace the `@payai/x402` dependency with upstream `@x402/core`, pinned to `2.21.0`.
+
+`@payai/x402` was a re-publish of upstream `@x402/core` from the now-abandoned PayAI x402 fork,
+and this package was pinned to a months-old `^2.2.4`. All protocol type imports
+(`@payai/x402/types`) and `safeBase64Decode` (`@payai/x402/utils`) now resolve to the equivalent
+`@x402/core` subpath exports; no public API of `x402-solana` changes. `@payai/facilitator` is
+unaffected and remains the JWT auth dependency for the PayAI facilitator - it already declares
+`@x402/core` as its optional peer.

--- a/.changeset/upstream-x402-core.md
+++ b/.changeset/upstream-x402-core.md
@@ -1,5 +1,5 @@
 ---
-"x402-solana": minor
+"x402-solana": major
 ---
 
 Replace the `@payai/x402` dependency with upstream `@x402/core`, pinned to `2.21.0`.
@@ -7,6 +7,32 @@ Replace the `@payai/x402` dependency with upstream `@x402/core`, pinned to `2.21
 `@payai/x402` was a re-publish of upstream `@x402/core` from the now-abandoned PayAI x402 fork,
 and this package was pinned to a months-old `^2.2.4`. All protocol type imports
 (`@payai/x402/types`) and `safeBase64Decode` (`@payai/x402/utils`) now resolve to the equivalent
-`@x402/core` subpath exports; no public API of `x402-solana` changes. `@payai/facilitator` is
-unaffected and remains the JWT auth dependency for the PayAI facilitator - it already declares
-`@x402/core` as its optional peer.
+`@x402/core` subpath exports.
+
+`x402-solana`'s own functions, classes and signatures are unchanged. **However, the protocol types
+re-exported from `x402-solana/types` come straight from upstream, and four of them changed shape
+between `2.2.4` and `2.21.0`.** Code that only calls this package's API is unaffected; code that
+imports these types directly may need edits.
+
+### Breaking: re-exported protocol types
+
+- **`VerifyRequest` and `SettleRequest` gained a required `x402Version: number`.** If you build
+  these objects yourself, add the field. This matches what the facilitator has always required on
+  the wire.
+- **`PaymentPayload.resource` is now optional** (`resource?: ResourceInfo`). Reading it yields
+  `ResourceInfo | undefined`; guard before dereferencing.
+- **`ResourceInfo.description` and `ResourceInfo.mimeType` are now optional**, and the type gained
+  optional `serviceName`, `tags` and `iconUrl`. This cascades into `PaymentRequired["resource"]`
+  and therefore into `BeforePaymentContext.declaredResource` — a `beforePayment` hook reading
+  `declaredResource.description` now gets `string | undefined`.
+
+These are upstream corrections rather than regressions: a facilitator may legitimately omit all
+three fields, so the old required-everywhere types were overstating what arrives at runtime. They
+are deliberately **not** papered over with compatibility aliases, which would keep downstream code
+compiling while leaving it wrong at runtime.
+
+`PaymentRequirements`, `Network`, `Money`, `Price`, `AssetAmount`, `VerifyResponse`,
+`SettleResponse` and `SupportedResponse` are unchanged in both directions.
+
+`@payai/facilitator` is unaffected and remains the JWT auth dependency for the PayAI facilitator -
+it already declares `@x402/core` as its optional peer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "x402-solana",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x402-solana",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@payai/facilitator": "^2.2.4",
-        "@payai/x402": "^2.2.4",
         "@solana/spl-token": ">=0.4.14",
         "@solana/web3.js": ">=1.98.4",
+        "@x402/core": "2.21.0",
         "zod": "^4.3.5"
       },
       "devDependencies": {
@@ -2467,24 +2467,6 @@
         }
       }
     },
-    "node_modules/@payai/x402": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@payai/x402/-/x402-2.2.4.tgz",
-      "integrity": "sha512-P1ZVXTa4HMatsLaO2mU/mw0EnYpkw4uEshjsOIL0g1MgxDTxVDPNikNiYXFTs0ROttXCNQPZhu4KBcDcb0Ee2A==",
-      "license": "Proprietary",
-      "dependencies": {
-        "zod": "^3.24.2"
-      }
-    },
-    "node_modules/@payai/x402/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3828,6 +3810,24 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@x402/core": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.21.0.tgz",
+      "integrity": "sha512-0djKE7V5/JKDMrjRe5he3DoMFzlbVnUcvMmLAb2j6OoAJDamupkFh6fFrXeoHwjkBIxOFUzjGI4FVixz2dMxSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@payai/facilitator": "^2.2.4",
-    "@payai/x402": "^2.2.4",
     "@solana/spl-token": ">=0.4.14",
     "@solana/web3.js": ">=1.98.4",
+    "@x402/core": "2.21.0",
     "zod": "^4.3.5"
   },
   "peerDependencies": {

--- a/src/client/payment-interceptor.ts
+++ b/src/client/payment-interceptor.ts
@@ -1,5 +1,5 @@
-import type { PaymentRequirements, PaymentRequired } from "@payai/x402/types";
-import { safeBase64Decode } from "@payai/x402/utils";
+import type { PaymentRequirements, PaymentRequired } from "@x402/core/types";
+import { safeBase64Decode } from "@x402/core/utils";
 import type {
   BeforePaymentContext,
   BeforePaymentHook,

--- a/src/client/transaction-builder.ts
+++ b/src/client/transaction-builder.ts
@@ -13,7 +13,7 @@ import {
   TOKEN_PROGRAM_ID,
   TOKEN_2022_PROGRAM_ID,
 } from "@solana/spl-token";
-import type { PaymentRequirements } from "@payai/x402/types";
+import type { PaymentRequirements } from "@x402/core/types";
 import type { WalletAdapter } from "../types";
 
 // Constants for compute budget

--- a/src/server/facilitator-client.ts
+++ b/src/server/facilitator-client.ts
@@ -4,7 +4,7 @@ import type {
   VerifyResponse,
   SettleResponse,
   SupportedResponse,
-} from '@payai/x402/types';
+} from '@x402/core/types';
 import { getOrGenerateJwt } from '@payai/facilitator';
 import { isSolanaNetwork } from '../types';
 

--- a/src/server/payment-handler.ts
+++ b/src/server/payment-handler.ts
@@ -4,7 +4,7 @@ import type {
   VerifyResponse,
   SettleResponse,
   Network,
-} from '@payai/x402/types';
+} from '@x402/core/types';
 import type { X402ServerConfig, RouteConfig, TokenAsset } from '../types';
 import { toCAIP2Network } from '../types';
 import { getDefaultRpcUrl, getDefaultTokenAsset } from '../utils';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@
  */
 
 // ============================================
-// Import types from @payai/x402 package (v2)
+// Import types from @x402/core package (v2)
 // ============================================
 export type {
   // Protocol types (v2)
@@ -24,7 +24,7 @@ export type {
   Money,
   Price,
   AssetAmount,
-} from "@payai/x402/types";
+} from "@x402/core/types";
 
 // ============================================
 // SVM payload type (defined locally to avoid @x402/svm dependency)

--- a/src/types/solana-payment.ts
+++ b/src/types/solana-payment.ts
@@ -1,5 +1,5 @@
 import type { VersionedTransaction } from "@solana/web3.js";
-import type { PaymentRequirements, PaymentRequired } from "@payai/x402/types";
+import type { PaymentRequirements, PaymentRequired } from "@x402/core/types";
 import type { SolanaNetworkSimple } from "./x402-protocol";
 
 /**

--- a/src/types/x402-protocol.ts
+++ b/src/types/x402-protocol.ts
@@ -1,4 +1,4 @@
-import type { Network } from "@payai/x402/types";
+import type { Network } from "@x402/core/types";
 
 /**
  * Solana-specific x402 Protocol Types (v2)

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -3,7 +3,7 @@ import type {
   PaymentRequired,
   PaymentRequirements,
   PaymentPayload,
-} from "@payai/x402/types";
+} from "@x402/core/types";
 import {
   type TokenAsset,
   SOLANA_MAINNET_CAIP2,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
   clean: true,
   splitting: false,
   minify: false,
-  external: ['@solana/web3.js', '@solana/spl-token', 'zod', '@payai/x402'],
+  external: ['@solana/web3.js', '@solana/spl-token', 'zod', '@x402/core'],
   treeshake: true,
 });


### PR DESCRIPTION
## What

Drops `@payai/x402` in favor of upstream `@x402/core`, pinned to `2.21.0`.

`@payai/x402` is a re-publish of upstream `@x402/core` produced by the now-abandoned
`PayAINetwork/x402` fork (a build step string-replaced `@x402/*` → `@payai/*`). This package
was pinned to `^2.2.4`, months behind upstream, and ships it to real installers. Nothing here
used fork-specific behavior — only protocol types and one base64 helper.

> **Released as `major` (→ 3.0.0).** The dependency swap is mechanical, but this package
> re-exports upstream protocol types, and four of them changed shape between `2.2.4` and
> `2.21.0`. See [Breaking changes](#breaking-changes).

## Changes

| from | to | sites |
|---|---|---|
| `@payai/x402/types` | `@x402/core/types` | 7 |
| `@payai/x402/utils` (`safeBase64Decode`) | `@x402/core/utils` | 1 |

- `package.json`: `"@payai/x402": "^2.2.4"` → `"@x402/core": "2.21.0"` (pinned exactly).
- `tsup.config.ts`: `external` updated so core stays unbundled in `dist/`.
- `package-lock.json` regenerated on Linux (`node:22-slim` + npm 11) so the Linux-conditional
  optional deps (`@emnapi/runtime`, `bufferutil`, `utf-8-validate`) survive for `npm ci`.
  That also picks up the `2.0.5` → `2.1.0` root `version` field the last
  `chore: version packages` commit left stale in the lockfile.

**`@payai/facilitator` is deliberately untouched.** It is genuinely ours (JWT auth against the
PayAI facilitator), not a fork re-publish, and `@payai/facilitator@2.2.4` already declares
`@x402/core >=2.2.0` as an *optional peer* — which `2.21.0` satisfies, so the swap resolves that
peer rather than leaving it dangling.

Side benefit: the `@payai/x402` tarball declared `"license": "Proprietary"` over 100% upstream
Apache-2.0 code. That entry is now gone from our lockfile.

## Breaking changes

`x402-solana`'s own functions, classes and signatures are unchanged. The breaks are confined to
protocol types re-exported from `x402-solana/types`. Code that only calls this package's API is
unaffected.

| type | change | who breaks |
|---|---|---|
| `VerifyRequest` | gained required `x402Version: number` | producers |
| `SettleRequest` | gained required `x402Version: number` | producers |
| `PaymentPayload.resource` | `ResourceInfo` → `ResourceInfo?` | consumers |
| `ResourceInfo.description`, `.mimeType` | required → optional (plus new optional `serviceName`, `tags`, `iconUrl`) | consumers |

The `ResourceInfo` change cascades into `PaymentRequired["resource"]` and therefore into
`BeforePaymentContext.declaredResource` — a `beforePayment` hook reading
`declaredResource.description` now gets `string | undefined`.

These are upstream *corrections*, not regressions: a facilitator may legitimately omit all three
fields, and `x402Version` genuinely is on the wire. They are deliberately **not** papered over
with compatibility aliases, which would keep downstream code compiling while leaving it wrong at
runtime — and would rebuild the fork at the type level, which is the thing this PR exists to
delete.

`PaymentRequirements`, `Network`, `Money`, `Price`, `AssetAmount`, `VerifyResponse`,
`SettleResponse` and `SupportedResponse` are unchanged in both directions.

## Verification

**Type compatibility.** Both packages installed side by side and compiled under `strict`, with
assignability asserted in *both* directions across all twelve re-exported names. The harness was
validated against known-false controls first, so a silent pass isn't possible. That is what
surfaced the four breaks above; the other eight names came back clean both ways.

**Full CI sequence** re-run inside `node:22` on **Linux** against the regenerated lockfile:

```
### node v22.23.2 / npm 10.9.8
### npm ci        -> ok
### typecheck     -> tsc --noEmit, clean
### lint          -> eslint src/, clean
### test          -> Test Suites: 7 passed, 7 total
                     Tests:       102 passed, 102 total
### build         -> CJS + ESM + DTS, build success
```

Also verified locally on macOS:

- `dist/` references `@x402/core/utils` as an external import in both CJS and ESM — core is not
  bundled.
- CJS `require()` and ESM `import()` smoke tests of every entrypoint resolve and export the
  expected symbols.
- `examples/before-payment-guard.mjs` runs end-to-end against the rebuilt `dist/`
  (`PASS - payment refused, wallet never signed`), exercising the real `@x402/core`
  `safeBase64Decode` on the 402-parsing path.
- `changeset status` confirms the release resolves to **major**.

## Notes

This is the last consumer blocking deprecation of `@payai/x402` on npm.

The major bump is a judgment call worth a second opinion — the alternative was compatibility
aliases at `minor`, rejected for the reason above.

**Do not merge** — merging auto-deploys, so that call is the owner's.
