### PR TITLE
Optional TWZRD pre-signing hook on beforePayment

### DIFF
--- a/.changeset/twzrd-presign-hook.md
+++ b/.changeset/twzrd-presign-hook.md
@@ -1,0 +1,5 @@
+---
+"x402-solana": patch
+---
+
+Optional/recommended pre-signing verification adapter for `createTwzrdBeforePaymentHook` on the existing `beforePayment` seat. A block returns `{ abort: true, reason }` so the client throws its native `Payment aborted by beforePayment hook` error. Sign path unchanged.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,34 @@ wallet is never invoked on refusal) lives in
 npm run example:before-payment-guard
 ```
 
+#### Recommended pre-signing verification
+
+Optional hook that evaluates the selected `payTo` after requirement selection
+and before `signTransaction`. Use it to catch known malicious, drained, or
+non-responsive paywalls before committing on-chain gas/funds.
+
+A block must return `{ abort: true, reason }`. This client then throws its
+native `Error("Payment aborted by beforePayment hook: …")`. Do not throw a
+custom payload from the hook.
+
+```typescript
+import { createX402Client, asX402SolanaBeforePayment } from 'x402-solana/client';
+import { createTwzrdBeforePaymentHook } from 'twzrd-x402-gate';
+
+const client = createX402Client({
+  wallet,
+  network: 'solana',
+  beforePayment: asX402SolanaBeforePayment(
+    createTwzrdBeforePaymentHook({ refuseWashFlagged: true }),
+  ),
+});
+```
+
+`asX402SolanaBeforePayment` flattens x402 v2 `declaredResource.url` so the
+hook matches this package's 3.0.0 `BeforePaymentContext`. Install the optional
+gate with `npm i twzrd-x402-gate@0.8.16`. The sign path is unchanged when the
+hook is omitted.
+
 #### Using with a Proxy Server (CORS Bypass)
 
 If you're making requests from a browser to external APIs and encountering CORS issues, you can provide a custom fetch function that routes requests through your proxy server:

--- a/src/before-payment-adapter.ts
+++ b/src/before-payment-adapter.ts
@@ -1,0 +1,51 @@
+import type { BeforePaymentContext, BeforePaymentHook } from "./types";
+
+/**
+ * Flatten x402-solana@3.0.0 `declaredResource` (v2 resource object or string)
+ * to a URL string for hooks that bind on a string resource.
+ */
+export function adaptDeclaredResource(
+  context?: Pick<BeforePaymentContext, "declaredResource"> | {
+    declaredResource?: string | { url?: string };
+  },
+): string | undefined {
+  const raw = context?.declaredResource;
+  if (typeof raw === "string") return raw;
+  if (raw && typeof raw === "object" && "url" in raw && typeof raw.url === "string") {
+    return raw.url;
+  }
+  return undefined;
+}
+
+type TwzrdShapedHook = (
+  requirements: Parameters<BeforePaymentHook>[0],
+  context?: Omit<BeforePaymentContext, "declaredResource"> & {
+    declaredResource?: string;
+  },
+) => ReturnType<BeforePaymentHook>;
+
+/**
+ * Adapter for `createTwzrdBeforePaymentHook` (optional `twzrd-x402-gate`).
+ * Does not import that package. A block must be `{ abort: true, reason }`.
+ */
+export function asX402SolanaBeforePayment(hook: TwzrdShapedHook): BeforePaymentHook {
+  return async (requirements, context) => {
+    const declaredResource = adaptDeclaredResource(context);
+    const hookContext: Omit<BeforePaymentContext, "declaredResource"> & {
+      declaredResource?: string;
+    } = {
+      requestUrl: context.requestUrl,
+      responseUrl: context.responseUrl,
+      protocolVersion: context.protocolVersion,
+    };
+    if (context.signal !== undefined) hookContext.signal = context.signal;
+    if (declaredResource !== undefined) hookContext.declaredResource = declaredResource;
+    const decision = await hook(requirements, hookContext);
+    if (decision && decision.abort === true) {
+      return decision.reason !== undefined
+        ? { abort: true, reason: decision.reason }
+        : { abort: true };
+    }
+    return;
+  };
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -38,6 +38,11 @@ export class X402Client {
 /**
  * Create an x402 client instance
  */
+export {
+  adaptDeclaredResource,
+  asX402SolanaBeforePayment,
+} from "../before-payment-adapter";
+
 export function createX402Client(config: X402ClientConfig): X402Client {
   return new X402Client(config);
 }

--- a/tests/twzrd-presign-hook.test.ts
+++ b/tests/twzrd-presign-hook.test.ts
@@ -1,0 +1,92 @@
+/**
+ * createTwzrdBeforePaymentHook-shaped hook on x402-solana@3.0.0.
+ *
+ * Does not import twzrd-x402-gate (optional). Locks: 3.0.0 declaredResource
+ * object is flattened to .url; a block throws the native abort Error; the
+ * signer is never invoked.
+ */
+
+import type { VersionedTransaction } from '@solana/web3.js';
+import { createX402Client } from '../src/client';
+import { createSolanaPaymentTransaction } from '../src/client/transaction-builder';
+import type { BeforePaymentHook, WalletAdapter } from '../src/types';
+import {
+  mockWallet,
+  createV2PaymentRequiredResponse,
+} from './fixtures';
+import {
+  adaptDeclaredResource,
+  asX402SolanaBeforePayment,
+} from '../src/before-payment-adapter';
+
+jest.mock('../src/client/transaction-builder', () => ({
+  createSolanaPaymentTransaction: jest.fn(),
+}));
+
+const mockBuildAndSign = createSolanaPaymentTransaction as jest.MockedFunction<
+  typeof createSolanaPaymentTransaction
+>;
+
+function createSpyWallet(): WalletAdapter & {
+  signTransaction: jest.MockedFunction<WalletAdapter['signTransaction']>;
+} {
+  return {
+    ...mockWallet,
+    signTransaction: jest.fn(async (tx: VersionedTransaction) => tx),
+  };
+}
+
+const TEST_URL = 'https://api.example.com/test';
+
+describe('twzrd-shaped beforePayment on 3.0.0', () => {
+  beforeEach(() => {
+    mockBuildAndSign.mockReset();
+  });
+
+  it('flattens v2 declaredResource.url', () => {
+    expect(
+      adaptDeclaredResource({
+        declaredResource: {
+          url: 'https://api.example.com/test',
+          description: 'Test endpoint',
+          mimeType: 'application/json',
+        },
+      }),
+    ).toBe('https://api.example.com/test');
+    expect(adaptDeclaredResource({ declaredResource: 'https://plain.example' })).toBe(
+      'https://plain.example',
+    );
+  });
+
+  it('throws native Payment aborted error and does not sign', async () => {
+    const wallet = createSpyWallet();
+    const customFetch = jest.fn(async () => createV2PaymentRequiredResponse());
+
+    const twzrdShaped = async (
+      _requirements: unknown,
+      context?: { declaredResource?: string },
+    ) => {
+      expect(context?.declaredResource).toBe('https://api.example.com/test');
+      return {
+        abort: true as const,
+        reason: 'known_malicious_or_drained_paywall',
+      };
+    };
+
+    const beforePayment: BeforePaymentHook = asX402SolanaBeforePayment(twzrdShaped);
+
+    const client = createX402Client({
+      wallet,
+      network: 'solana-devnet',
+      customFetch: customFetch as unknown as typeof fetch,
+      beforePayment,
+    });
+
+    await expect(client.fetch(TEST_URL)).rejects.toThrow(
+      'Payment aborted by beforePayment hook: known_malicious_or_drained_paywall',
+    );
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(0);
+    expect(mockBuildAndSign).toHaveBeenCalledTimes(0);
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Optional/recommended pre-signing verification hook to catch known malicious, drained, or non-responsive paywalls before committing on-chain gas/funds.

## Boundary
- Uses the existing `beforePayment` seat on `createX402Client` (after requirement select, before sign). No change to the sign path.
- A block is `{ abort: true, reason }`. The client throws its native `Error("Payment aborted by beforePayment hook: …")`. The hook does not throw a custom payload.
- Types match this package at 3.0.0 (`BeforePaymentContext.declaredResource` is the v2 resource object). `asX402SolanaBeforePayment` flattens `.url` for `createTwzrdBeforePaymentHook`.
- `twzrd-x402-gate` is optional (`npm i twzrd-x402-gate@0.8.16`). Not a dependency.

## Test
`npx jest tests/twzrd-presign-hook.test.ts tests/beforePayment.test.ts` — 12 pass. Typecheck clean.

Does not import `twzrd-x402-gate` in CI.